### PR TITLE
Add __toString to `PointInterface`

### DIFF
--- a/src/Common/Point.php
+++ b/src/Common/Point.php
@@ -66,4 +66,12 @@ class Point implements PointInterface
     {
         return array($this->x, $this->y);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->x . ',' . $this->y;
+    }
 }

--- a/src/Common/PointInterface.php
+++ b/src/Common/PointInterface.php
@@ -62,4 +62,11 @@ interface PointInterface
      * @return array
      */
     public function getCoordinates();
+
+    /**
+     * Return a basic string representation.
+     *
+     * @return string
+     */
+    public function __toString();
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Point Reduction Algorithms library.
- * 
+ *
  * PHP Version 5.4
  *
  * @category   PointReduction
@@ -59,5 +59,32 @@ class PointTest extends PHPUnit_Framework_TestCase
          $point = new Point(3.4, 6.8);
          $actual = $point->getCoordinates();
          $this->assertEquals(array(3.4, 6.8), $actual);
+     }
+
+    /**
+     * Smoke test point object interface
+     *
+     * @test
+     * @smoke
+     * @covers \PointReduction\Common\Point::__construct
+     * @covers \PointReduction\Common\Point::__toString
+     *
+     * @return null
+     */
+     public function testToString()
+     {
+         $point = new Point(3.4, 6.8);
+         $string = $point->__toString();
+         $this->assertEquals('3.4,6.8', $string);
+
+         $string = (string) $point;
+         $this->assertEquals('3.4,6.8', $string);
+
+         $points = [
+            new Point(1, 2),
+            new Point(3, 4),
+         ];
+         $string = implode(' ', $points);
+         $this->assertEquals('1,2 3,4', $string);
      }
 }


### PR DESCRIPTION
Add __toString to `PointInterface` to be able to cast one point or even a points collection to string representation.
